### PR TITLE
Numerics map output

### DIFF
--- a/imctrans/cpp/assets/src/IMC/Base/Message.hpp
+++ b/imctrans/cpp/assets/src/IMC/Base/Message.hpp
@@ -23,6 +23,7 @@
 #include <iomanip>
 #include <cstring>
 #include <sstream>
+#include <map>
 
 // IMC headers.
 #include "Config.hpp"
@@ -233,6 +234,15 @@ namespace IMC
     setValueFP(double val)
     {
       (void)val;
+    }
+
+    //! Get a map containing the first non-nested numerical values
+    //! that are not enumerations or bitfields
+    //! @return flat map<std::string, double>
+    virtual std::map<std::string, double>
+    getFlatNumericsMap(void) const
+    {
+        return std::map<std::string, double>();
     }
 
     //! Compute the amount of bytes required to properly serialize

--- a/imctrans/cpp/assets/src/IMC/Base/Message.hpp
+++ b/imctrans/cpp/assets/src/IMC/Base/Message.hpp
@@ -32,6 +32,8 @@
 #include "Exceptions.hpp"
 #include "Clock.hpp"
 
+#define IMC_VERSION_HAS_GETFLATNUMERICSMAP 1
+
 // IMC API headers.
 #include <IMC/Spec/Constants.hpp>
 #include <IMC/Spec/Header.hpp>


### PR DESCRIPTION
This is used to get a map of all the numeric values in the message. Useful for generic third-party log analysis for instance. 