### PR TITLE
Platforms: Add aarch64 (Nvidia Jetson support)

### DIFF
--- a/imctrans/cpp/assets/src/IMC/Base/Platform.hpp
+++ b/imctrans/cpp/assets/src/IMC/Base/Platform.hpp
@@ -62,6 +62,12 @@
 #  define IMC_CPU_32B           1
 #  define IMC_CPU_NAME          "arm"
 
+#elif defined(__aarch64__)
+#  define IMC_CPU_ARM64
+#  define IMC_CPU_LE            1
+#  define IMC_CPU_64B           1
+#  define IMC_CPU_NAME          "arm64"
+
 #else
 #  error unknown architecture
 


### PR DESCRIPTION
This change makes this work on platforms such as Nvidia's Jetson. 